### PR TITLE
Fix the FAQ link

### DIFF
--- a/website/manuals/guides/troubleshooting/index.md
+++ b/website/manuals/guides/troubleshooting/index.md
@@ -8,7 +8,7 @@ footer: false
 
 Facing source or app issues? Here's how to troubleshoot.
 
-Be sure to check the [Frequently Asked Questions]() for how to address common issues too.
+Be sure to check the [Frequently Asked Questions](/manuals/faq/general/) for how to address common issues too.
 
 ## WebView
 


### PR DESCRIPTION
The FAQ link is lacking a link, this pull request fix it by linking to what I assume it is suppose to link to.